### PR TITLE
Build with `docker-compose`

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   federator:
     container_name: eidaws-federator
     image: eidaws-federator:1.1.2
+    build:
+      context: .
+      dockerfile: ./federator/Dockerfile
     restart: always
     logging:
       driver: "json-file"
@@ -56,6 +59,9 @@ services:
   endpoint-proxy:
     container_name: eidaws-endpoint-proxy
     image: eidaws-endpoint-proxy:1.1.2
+    build:
+      context: .
+      dockerfile: ./proxy/Dockerfile
     restart: always
     logging:
       driver: "json-file"
@@ -80,6 +86,9 @@ services:
   stationlite:
     container_name: eidaws-stationlite
     image: eidaws-stationlite:1.1.2
+    build:
+      context: .
+      dockerfile: ./stationlite/Dockerfile
     env_file:
       - env
     restart: always

--- a/docs/docker-compose/README.rst
+++ b/docs/docker-compose/README.rst
@@ -47,7 +47,7 @@ In order to build ``eidaws-endpoint-proxy`` container image, invoke
 
 .. code::
 
-  $ docker build -t eidaws-endpoint-proxy:1.1.1 -f proxy/Dockerfile .
+  $ docker build -t eidaws-endpoint-proxy:1.1.2 -f proxy/Dockerfile .
 
 
 The ``eidaws-endpoint-proxy`` container implements both proxy facilites and
@@ -68,7 +68,7 @@ Next, build the ``eidaws-stationlite`` container image with
 
 .. code::
 
-  $ docker build -t eidaws-stationlite:1.1.1 -f stationlite/Dockerfile .
+  $ docker build -t eidaws-stationlite:1.1.2 -f stationlite/Dockerfile .
 
 
 eidaws-federator
@@ -79,7 +79,7 @@ service component:
 
 .. code::
 
-  $ docker build [--build-arg=INSTANCE_XXX=20] -t eidaws-federator:1.1.1 \
+  $ docker build [--build-arg=INSTANCE_XXX=20] -t eidaws-federator:1.1.2 \
     -f federator/Dockerfile .
 
 Note that the ``federator/Dockerfile`` allows the number of backend

--- a/docs/docker-compose/README.rst
+++ b/docs/docker-compose/README.rst
@@ -37,56 +37,40 @@ Building
 ========
 
 The ``eidaws-federator`` deployment is subdevided into several components. While
-some of the container images are downloaded from a container registry the
-following containers must be build manually:
+some of the container images are downloaded from a container registry some
+containers must be build manually. The following containers require special
+preparation and/or configuration:
 
-eidaws-endpoint-proxy
----------------------
+- **eidaws-stationlite**
 
-In order to build ``eidaws-endpoint-proxy`` container image, invoke
+  ``eidaws-stationlite`` implements ``eidaws-federator``'s routing facilities.
 
-.. code::
+  Before building and running the ``eidaws-stationlite`` container adjust the
+  variables defined within the ``docker-compose/env`` configuration file
+  according to your needs. Make sure to pick a proper username and password for
+  the internally used PostgreSQL_ database and write these down for later.
 
-  $ docker build -t eidaws-endpoint-proxy:1.1.2 -f proxy/Dockerfile .
+- **eidaws-federator**
 
+  ``eidaws-federator`` implements the actual federating service component.
 
-The ``eidaws-endpoint-proxy`` container implements both proxy facilites and
-caching facilities.
+  The ``federator/Dockerfile`` file allows the number of federating backend
+  service instances to be optionally configured during build time. For this
+  reason the following build args ``INSTANCES_DATASELECT_MINISEED``,
+  ``INSTANCES_STATION_TEXT``, ``INSTANCES_STATION_XML`` and
+  ``INSTANCES_WFCATALOG_JSON`` are provided.
 
-
-eidaws-stationlite
-------------------
-
-``eidaws-stationlite`` implements ``eidaws-federator``'s routing facilities.
-
-Before building and running the ``eidaws-stationlite`` container adjust the
-variables defined within the ``docker-compose/env`` configuration file
-according to your needs. Make sure to pick a proper username and password for
-the internally used PostgreSQL_ database and write these down for later.
-
-Next, build the ``eidaws-stationlite`` container image with
-
-.. code::
-
-  $ docker build -t eidaws-stationlite:1.1.2 -f stationlite/Dockerfile .
+  While building these build time variables may be provided by means of the
+  ``--build-arg`` CLI flag (i.e.  ``--build-arg=INSTANCES_XXX=N``, where
+  ``N`` corresponds to the number of ``XXX`` type federating backend service
+  instances to be created).
 
 
-eidaws-federator
-----------------
-
-Finally, it is time to build ``eidaws-federator``, the actual federating
-service component:
+Finally, the containers are built with:
 
 .. code::
 
-  $ docker build [--build-arg=INSTANCE_XXX=20] -t eidaws-federator:1.1.2 \
-    -f federator/Dockerfile .
-
-Note that the ``federator/Dockerfile`` allows the number of backend
-applications to be configured during build time. The build args
-``INSTANCES_DATASELECT_MINISEED``, ``INSTANCES_STATION_TEXT``,
-``INSTANCES_STATION_XML`` and ``INSTANCES_WFCATALOG_JSON`` are provided in
-order to configure the number of federating backend services.
+  $ docker-compose -f docker-compose.yml build [--build-arg=INSTANCES_XXX=N]
 
 
 Deployment


### PR DESCRIPTION
**Features and Changes**:
- Use `docker-compose` for building containers; simplify building procedure