### PR TITLE
Override HTTPS routing URLs

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -85,7 +85,7 @@ services:
   # eidaws-stationlite
   stationlite:
     container_name: eidaws-stationlite
-    image: eidaws-stationlite:1.1.3
+    image: eidaws-stationlite:1.1.4
     build:
       context: .
       dockerfile: ./stationlite/Dockerfile

--- a/docker-compose/stationlite/eidaws_stationlite_harvest_config.yml
+++ b/docker-compose/stationlite/eidaws_stationlite_harvest_config.yml
@@ -58,6 +58,13 @@ services:
   - wfcatalog
 #
 # ----
+# Strictly use the 'https' scheme for routing URLs if provided. By default the
+# 'https' scheme of routing URLs is overridden falling back to the
+# corresponding 'http' scheme.
+#
+# strict-https: False
+#
+# ----
 # Perform a strict validaation of channel epochs to use the correct
 # dataselect method token depending on their restricted status. By default
 # method tokens are adjusted automatically.


### PR DESCRIPTION
**Features and Changes**:
- Make use of features implemented by https://github.com/EIDA/eidaws/pull/29; cope with HTTPS routing URLs