### PR TITLE
Update http.conf

### DIFF
--- a/docker-compose/federator/conf.d/http.conf
+++ b/docker-compose/federator/conf.d/http.conf
@@ -88,7 +88,7 @@ http {
       alias /var/www/eidaws-federator/static/$1/$2;
     }
 
-    location ~ ^/(fdsnws/(dataselect|station))|(fdsnws)|(eidaws)|(eidaws/wfcatalog)/1/$ {
+    location ~ ^/(fdsnws/(dataselect|station)/1/$)|(fdsnws/$)|(eidaws/$)|(eidaws/wfcatalog/1/$) {
       # redirect to landing page
       rewrite ^ / last;
     }


### PR DESCRIPTION
previous expression matched /fdsnws*, i.e. also /fdsnws/event/..., resulting in crashes of some applications finding the default page at /fdsnws/event/1/application.wadl and trying to parse it

(the proposed solution is still not very elegant...)